### PR TITLE
DCWL-2100 Remove JVM option in build sbt ready for Java 21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,10 @@ import play.sbt.PlayImport.PlayKeys.playDefaultPort
 import sbt.Keys._
 import sbt.Tests.{Group, SubProcess}
 import sbt.{Setting, _}
-import uk.gov.hmrc.DefaultBuildSettings.{addTestReportOption, targetJvm}
+import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
 import uk.gov.hmrc.gitstamp.GitStampPlugin._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
+import scala.collection.Seq
 
 import scala.language.postfixOps
 
@@ -30,7 +31,6 @@ lazy val microservice = (project in file("."))
   .settings(playDefaultPort := 9648)
   .settings(
     scalaVersion := "2.13.13",
-    targetJvm := "jvm-11",
     commonSettings,
     unitTestSettings,
     integrationComponentTestSettings,


### PR DESCRIPTION
Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests