### PR TITLE
DCWL-4404 Reverts the mongo query hint applied when fetching pulled/unpulled notification ids

### DIFF
--- a/app/uk/gov/hmrc/apinotificationqueue/repository/NotificationRepository.scala
+++ b/app/uk/gov/hmrc/apinotificationqueue/repository/NotificationRepository.scala
@@ -262,7 +262,7 @@ class NotificationMongoRepository @Inject()(mongo: MongoComponent,
 
     collection.aggregate[NotificationWithIdOnly](
       pipeline = Seq(filter, projection)
-    ).hintString("clientId-Index").toFuture().map(_.toList)
+    ).toFuture().map(_.toList)
   }
 
     override def fetchNotificationIds(clientId: String, conversationId: UUID, notificationStatus: NotificationStatus.Value): Future[List[NotificationWithIdOnly]] = {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  val mongoVersion      = "2.11.0"
+  val mongoVersion      = "2.12.0"
   val bootstrapVersion  = "10.5.0"
   val playSuffix        = "-play-30"
 


### PR DESCRIPTION


Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests